### PR TITLE
Web service API supporting 

### DIFF
--- a/src/GrpcServer/Program.cs
+++ b/src/GrpcServer/Program.cs
@@ -53,7 +53,9 @@ namespace GrpcServer
                 .ConfigureServices(x => x.AddRouting())
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .Build();
-            host.Run();
+            host.RunAsync();
+            
+            
         }
     }
 
@@ -72,7 +74,7 @@ namespace GrpcServer
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.TryAddSingleton<ISampleService, SampleService>();
+            services.TryAddSingleton<SampleService>();
             services.AddSoapCore();
         }
 
@@ -91,12 +93,11 @@ namespace GrpcServer
                 });
             });
 
-            app.UseSoapEndpoint<ISampleService>("/Service.svc", new BasicHttpBinding(),
+            app.UseSoapEndpoint<SampleService>("/Service.svc", new BasicHttpBinding(),
                 SoapSerializer.DataContractSerializer);
-            app.UseSoapEndpoint<ISampleService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
+            app.UseSoapEndpoint<SampleService>("/Service.asmx", new BasicHttpBinding(), SoapSerializer.XmlSerializer);
 
-            app.Run(context =>
-                context.Response.WriteAsync("Default"));
+            app.Run(context => context.Response.WriteAsync("Default"));
         }
     }
 }

--- a/src/GrpcServer/Service.cs
+++ b/src/GrpcServer/Service.cs
@@ -19,22 +19,27 @@ namespace GrpcServer
         double
         complex
         
-     + RootOfTheService
-        + MyNamedService
-            +Method1
-                + ReturnsType
-                    + Type
-                + Arguments
-                    + Arg1
-                        + Type
-                    + Arg2
-                        + Type
-                    + Arg3
-                        + Type
-            +Method2
-                ...
-            +Method3
-                ...
+    + Root
+        + SerializableTypes
+             + MyComplexType
+                    + MyProperty
+
+        + Web-Services
+            + MyNamedService
+                +Method1
+                    + ReturnsType
+                        + MyComplexType
+                    + Arguments
+                        + Arg1
+                            + string
+                        + Arg2
+                            + int
+                        + Arg3
+                            + MyComplexType
+                +Method2
+                    ...
+                +Method3
+                    ...
      */
 
 
@@ -105,14 +110,15 @@ namespace GrpcServer
     }
 
 
+    [ServiceContract]
     public class SampleService : ISampleService
-    {
+    {[OperationContract]
         public string Ping(string s)
         {
             Console.WriteLine("Exec ping method");
             return s;
         }
-
+        [OperationContract]
         public ComplexModelResponse PingComplexModel(ComplexModelInput inputModel)
         {
             Console.WriteLine("Input data. IntProperty: {0}, StringProperty: {1}", inputModel.IntProperty,
@@ -126,22 +132,22 @@ namespace GrpcServer
                 DateTimeOffsetProperty = inputModel.DateTimeOffsetProperty
             };
         }
-
+        [OperationContract]
         public void VoidMethod(out string s)
         {
             s = "Value from server";
         }
-
+        [OperationContract]
         public Task<int> AsyncMethod()
         {
             return Task.Run(() => 42);
         }
-
+        [OperationContract]
         public int? NullableMethod(bool? arg)
         {
             return null;
         }
-
+        [OperationContract]
         public void XmlMethod(XElement xml)
         {
             Console.WriteLine(xml.ToString());


### PR DESCRIPTION
Представляю себе такую картину:

Веб сервис - это отдельная ветка конфигурации с метаданными, описывающими его.

Все типы веб сервиса - это метаданные (SerializableTypes) , которые лежат отдельно. В отличие от DTO типов, описывающих данные в базе, у них нет служебных полей и их может вертеть пользователь как хочет. Это очень удобно для внешних интеграций.

Как это выглядит в проекте
```
    + Root
        + SerializableTypes
             + MyComplexType
                    + MyProperty

        + Web-Services
            + MyNamedService
                +Method1
                    + ReturnsType
                        + MyComplexType
                    + Arguments
                        + Arg1
                            + string
                        + Arg2
                            + int
                        + Arg3
                            + MyComplexType
                +Method2
                    ...
                +Method3
                    ...
```
Q: Почему нельзя описать их как классы в отдельных файлах? Это же проще и удобнее
A: Если мы опишем их как классы в отдельных файлах, в таком случае потеряется ссылочная связь между типами и описанием веб сервиса.

Close #3  

